### PR TITLE
Make phploc $result nullable

### DIFF
--- a/src/Enrichers/PHPLOC/PHPLOCEnricher.php
+++ b/src/Enrichers/PHPLOC/PHPLOCEnricher.php
@@ -15,7 +15,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class PHPLOCEnricher extends Enricher
 {
-    private array $result;
+    private ?array $result;
 
     public function prepare(): void
     {


### PR DESCRIPTION
Cause otherwise php error stucks on json_decode if file content is not a valid json.